### PR TITLE
Exclude github-actions[bot] PRs from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - github-actions[bot]


### PR DESCRIPTION
Add `.github/release.yml` to exclude CHANGELOG auto-update PRs (created by `github-actions[bot]`) from GitHub release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)