### PR TITLE
Fix: increase max_tokens to 2048 for vLLM with thinking models

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -934,7 +934,7 @@ export default class RepoNotesPlugin extends Plugin {
     }
     const body = JSON.stringify({
       model: this.settings.summaryModel,
-      max_tokens: 1024,
+      max_tokens: 2048,
       temperature: 0.3,
       top_p: 0.9,
       messages: [


### PR DESCRIPTION
The 1024 value was still too small for models that use extended thinking, causing all tokens to be consumed in reasoning_content leaving content null. Bump to 2048.